### PR TITLE
Send the real currentFormat in setFonts()

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleTranscodingTrackOutput.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleTranscodingTrackOutput.java
@@ -93,7 +93,6 @@ public final class SubtitleTranscodingTrackOutput implements TrackOutput {
     checkNotNull(format.sampleMimeType);
     checkArgument(MimeTypes.getTrackType(format.sampleMimeType) == C.TRACK_TYPE_TEXT);
     if (!format.equals(currentFormat)) {
-      currentFormat = format;
       switch (format.sampleMimeType) {
         case MimeTypes.TEXT_SSA:
           // TODO Remove hack. We suppose that when extensionRendererMode is NOT EXTENSION_RENDERER_MODE_OFF,
@@ -123,20 +122,23 @@ public final class SubtitleTranscodingTrackOutput implements TrackOutput {
                   : null;
       }
     }
+
+    // Ensure currentFormat always matches what is sent to the delegate,
+    // as it's used later in setFonts().
     if (currentSubtitleParser == null) {
-      delegate.format(format);
+      currentFormat = format;
     } else {
-      delegate.format(
-          format
-              .buildUpon()
-              .setSampleMimeType(MimeTypes.APPLICATION_MEDIA3_CUES)
-              .setCodecs(format.sampleMimeType)
-              // Reset this value to the default. All non-default timestamp adjustments are done
-              // below in sampleMetadata() and there are no 'subsamples' after transcoding.
-              .setSubsampleOffsetUs(Format.OFFSET_SAMPLE_RELATIVE)
-              .setCueReplacementBehavior(subtitleParserFactory.getCueReplacementBehavior(format))
-              .build());
+      currentFormat = format
+                          .buildUpon()
+                          .setSampleMimeType(MimeTypes.APPLICATION_MEDIA3_CUES)
+                          .setCodecs(format.sampleMimeType)
+                          // Reset this value to the default. All non-default timestamp adjustments are done
+                          // below in sampleMetadata() and there are no 'subsamples' after transcoding.
+                          .setSubsampleOffsetUs(Format.OFFSET_SAMPLE_RELATIVE)
+                          .setCueReplacementBehavior(subtitleParserFactory.getCueReplacementBehavior(format))
+                          .build();
     }
+    delegate.format(currentFormat);
   }
 
   @Override


### PR DESCRIPTION
Le currentFormat peut ne pas représenter réellement le vrai format, car on ne sauvegardait pas le format qui est modifier. C'est un bug présent dans media3, mais ce [commit](https://github.com/moi15moi/media/pull/1/commits/c68cc13c0b7fa2b7a68a3cb20145f9cd1388fe91) permet de s'en apercevoir, car à partir de celui-ci, l'implémentation SANS notre décodeur plante, car le ``SampleMimeType`` n'est pas APPLICATION_MEDIA3_CUES.

Auparavant, on ne pouvait pas s'en apercevoir, car on n'envoyait jamais le currentFormat via delegate.format(format). Désormais, on l'envoit dans la méthode setFonts.