### PR TITLE
Refactor: using function names pattern

### DIFF
--- a/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
+++ b/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
@@ -21,12 +21,12 @@ public class LibassJNI {
       throw new RuntimeException("Libass native library is not available");
     }
 
-    assLibraryPtr = initAssLibrary();
+    assLibraryPtr = assLibraryInit();
     if (assLibraryPtr == 0) {
       throw new RuntimeException("Failed to initialize ASS_Library");
     }
 
-    assRendererPtr = initAssRenderer(assLibraryPtr);
+    assRendererPtr = assRendererInit(assLibraryPtr);
     if (assRendererPtr == 0) {
       throw new RuntimeException("Failed to initialize ASS_Renderer");
     }
@@ -51,7 +51,7 @@ public class LibassJNI {
    * @param height The height of the storage in pixels.
    */
   public void setStorageSize(int width, int height) {
-      setStorageSizeNative(assRendererPtr, width, height);
+    assSetStorageSize(assRendererPtr, width, height);
   }
 
   /**
@@ -65,7 +65,7 @@ public class LibassJNI {
       return;
     }
 
-    long trackPtr = createTrackNative(assLibraryPtr);
+    long trackPtr = assNewTrack(assLibraryPtr);
     if (trackPtr == 0) {
       throw new RuntimeException("Failed to create ASS_Track");
     }
@@ -80,12 +80,12 @@ public class LibassJNI {
    */
   public void releaseTrack(String trackId) {
     Long trackPtr = assTrackPtrs.remove(trackId);
-    destroyTrackNative(trackPtr);
+    assFreeTrack(trackPtr);
     Log.d(TAG, "Released track with ID: " + trackId);
   }
 
   /**
-   * Prepares and formats data to then call {@link #processChunkNative}()}.
+   * Prepares and formats data to then call {@link #assProcessChunk}()}.
    *
    * @param data The ass subtitle event.
    * @param offset The index in {@code data} to start reading from (inclusive).
@@ -140,7 +140,7 @@ public class LibassJNI {
     int line_offset = secondComma + 1;
     int line_length = offset + length - secondComma - 1;
 
-    processChunkNative(trackPtr, data, line_offset, line_length, timecode, durationMs);
+    assProcessChunk(trackPtr, data, line_offset, line_length, timecode, durationMs);
   }
 
   /**
@@ -151,7 +151,7 @@ public class LibassJNI {
    */
   public void processCodecPrivate(String trackId, byte[] data) {
     Long trackPtr = assTrackPtrs.get(trackId);
-    processCodecPrivateNative(trackPtr, data);
+    assProcessCodecPrivate(trackPtr, data);
     Log.d(TAG, "Processed codec private data for track ID: " + trackId);
   }
 
@@ -181,7 +181,7 @@ public class LibassJNI {
    * @param fontData The raw byte data of the font.
    */
   public void loadFont(String fileName, byte[] fontData) {
-    addFont(assLibraryPtr, fileName, fontData);
+    assAddFont(assLibraryPtr, fileName, fontData);
   }
 
   @Override
@@ -189,16 +189,16 @@ public class LibassJNI {
     try {
       for (Map.Entry<String, Long> entry : assTrackPtrs.entrySet()) {
         if (entry.getValue() != 0) {
-          destroyTrackNative(entry.getValue());
+          assFreeTrack(entry.getValue());
           Log.d(TAG, "Finalized track: " + entry.getKey());
         }
       }
 
       if (assRendererPtr != 0) {
-        destroyAssRenderer(assRendererPtr);
+        assRendererDone(assRendererPtr);
       }
       if (assLibraryPtr != 0) {
-        destroyAssLibrary(assLibraryPtr);
+        assLibraryDone(assLibraryPtr);
       }
     } finally {
       super.finalize();
@@ -212,20 +212,20 @@ public class LibassJNI {
    * @param fontName The name of the font.
    * @param fontData The raw byte data of the font.
    */
-  private native void addFont(long assLibraryPtr, String fontName, byte[] fontData);
+  private native void assAddFont(long assLibraryPtr, String fontName, byte[] fontData);
 
   /**
    * Initializes the native ASS_Library and returns its pointer as a long.
    * This pointer must be passed to native methods that require it.
    */
-  private native long initAssLibrary();
+  private native long assLibraryInit();
 
   /**
    * Destroys the native ASS_Library instance.
    *
    * @param assLibraryPtr The pointer to the native ASS_Library instance.
    */
-  private native void destroyAssLibrary(long assLibraryPtr);
+  private native void assLibraryDone(long assLibraryPtr);
 
   /**
    * Initializes the native ASS_Renderer and returns its pointer as a long.
@@ -234,14 +234,14 @@ public class LibassJNI {
    * @param assLibraryPtr The pointer to the native ASS_Library instance.
    * @return The pointer to the native ASS_Renderer instance.
    */
-  private native long initAssRenderer(long assLibraryPtr);
+  private native long assRendererInit(long assLibraryPtr);
 
   /**
    * Destroys the native ASS_Renderer instance.
    *
    * @param assRendererPtr The pointer to the native ASS_Renderer instance.
    */
-  private native void destroyAssRenderer(long assRendererPtr);
+  private native void assRendererDone(long assRendererPtr);
 
   /**
    * Sets the frame size for the ASS_Renderer.
@@ -250,7 +250,7 @@ public class LibassJNI {
    * @param width The width of the frame in pixels.
    * @param height The height of the frame in pixels.
    */
-  private native void setFrameSizeNative(long assRendererPtr, int width, int height);
+  private native void assSetFrameSize(long assRendererPtr, int width, int height);
 
   /**
    * Sets the storage size for the ASS_Renderer.
@@ -259,7 +259,7 @@ public class LibassJNI {
    * @param width The width of the storage in pixels.
    * @param height The height of the storage in pixels.
    */
-  private native void setStorageSizeNative(long assRendererPtr, int width, int height);
+  private native void assSetStorageSize(long assRendererPtr, int width, int height);
 
   /**
    * Creates a new ASS_Track instance.
@@ -267,14 +267,14 @@ public class LibassJNI {
    * @param assLibraryPtr The pointer to the native ASS_Library instance.
    * @return The pointer to the created ASS_Track instance.
    */
-  private native long createTrackNative(long assLibraryPtr);
+  private native long assNewTrack(long assLibraryPtr);
 
   /**
    * Destroys the ASS_Track instance.
    *
    * @param assTrackPtr The pointer to the native ASS_Track instance.
    */
-  private native void destroyTrackNative(long assTrackPtr);
+  private native void assFreeTrack(long assTrackPtr);
 
 
   /**
@@ -287,7 +287,7 @@ public class LibassJNI {
    * @param timecode The timestamp in milliseconds.
    * @param duration The duration of the event.
    */
-  private native void processChunkNative(long assTrackPtr, byte[] eventData, int offset, int length, long timecode, long duration);
+  private native void assProcessChunk(long assTrackPtr, byte[] eventData, int offset, int length, long timecode, long duration);
 
 
   private native AssRenderResult renderFrameNative(long assRendererPtr, long assTrackPtr, int frame_width, int frame_height, long timeMs);
@@ -299,5 +299,5 @@ public class LibassJNI {
    * @param assTrackPtr The pointer to the native ASS_Track instance.
    * @param data The codec private data bytes.
    */
-  private native void processCodecPrivateNative(long assTrackPtr, byte[] data);
+  private native void assProcessCodecPrivate(long assTrackPtr, byte[] data);
 }

--- a/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
+++ b/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
@@ -8,13 +8,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class LibassJNI {
+
   private final String TAG = "LibassJNI";
   private final long assLibraryPtr;
   private final long assRendererPtr;
   private final Map<String, Long> assTrackPtrs = new HashMap<>();
 
-  @Nullable private Integer frame_width = null;
-  @Nullable private Integer frame_height = null;
+  @Nullable
+  private Integer frame_width = null;
+  @Nullable
+  private Integer frame_height = null;
 
   public LibassJNI() {
     if (!AssLibrary.isAvailable()) {
@@ -35,19 +38,19 @@ public class LibassJNI {
   /**
    * Sets the frame size for the ASS_Renderer.
    *
-   * @param width The width of the frame in pixels.
+   * @param width  The width of the frame in pixels.
    * @param height The height of the frame in pixels.
    */
   public void setFrameSize(int width, int height) {
-      frame_width = width;
-      frame_height = height;
-      setFrameSizeNative(assRendererPtr, width, height);
+    frame_width = width;
+    frame_height = height;
+    assSetFrameSize(assRendererPtr, width, height);
   }
 
   /**
    * Sets the storage size for the ASS_Renderer.
    *
-   * @param width The width of the storage in pixels.
+   * @param width  The width of the storage in pixels.
    * @param height The height of the storage in pixels.
    */
   public void setStorageSize(int width, int height) {
@@ -87,11 +90,11 @@ public class LibassJNI {
   /**
    * Prepares and formats data to then call {@link #assProcessChunk}()}.
    *
-   * @param data The ass subtitle event.
-   * @param offset The index in {@code data} to start reading from (inclusive).
-   * @param length The number of bytes to read from {@code data}.
+   * @param data     The ass subtitle event.
+   * @param offset   The index in {@code data} to start reading from (inclusive).
+   * @param length   The number of bytes to read from {@code data}.
    * @param timecode The timestamp in milliseconds.
-   * @param trackId The ID of the track to process subtitles from.
+   * @param trackId  The ID of the track to process subtitles from.
    */
   public void prepareProcessChunk(
       byte[] data,
@@ -159,7 +162,7 @@ public class LibassJNI {
    * Renders a frame for a specific track at the given timestamp.
    *
    * @param trackId The ID of the track to render.
-   * @param timeMs The timestamp in milliseconds.
+   * @param timeMs  The timestamp in milliseconds.
    * @return A bitmap with the rendered subtitle image, or null if no image was rendered.
    */
   public AssRenderResult renderFrame(String trackId, long timeMs) {
@@ -168,10 +171,10 @@ public class LibassJNI {
       Log.w(TAG, "The trackID '" + trackId + "' isn't registered.");
       return null;
     }
-    if (frame_width == null || frame_height == null){
+    if (frame_width == null || frame_height == null) {
       throw new RuntimeException("Frame size has not been set");
     }
-    return renderFrameNative(assRendererPtr, trackPtr, frame_width, frame_height, timeMs);
+    return assRenderFrame(assRendererPtr, trackPtr, frame_width, frame_height, timeMs);
   }
 
   /**
@@ -209,8 +212,8 @@ public class LibassJNI {
    * Adds a font to the ASS_Library.
    *
    * @param assLibraryPtr The pointer to the native ASS_Library instance.
-   * @param fontName The name of the font.
-   * @param fontData The raw byte data of the font.
+   * @param fontName      The name of the font.
+   * @param fontData      The raw byte data of the font.
    */
   private native void assAddFont(long assLibraryPtr, String fontName, byte[] fontData);
 
@@ -247,8 +250,8 @@ public class LibassJNI {
    * Sets the frame size for the ASS_Renderer.
    *
    * @param assRendererPtr The pointer to the native ASS_Renderer instance.
-   * @param width The width of the frame in pixels.
-   * @param height The height of the frame in pixels.
+   * @param width          The width of the frame in pixels.
+   * @param height         The height of the frame in pixels.
    */
   private native void assSetFrameSize(long assRendererPtr, int width, int height);
 
@@ -256,8 +259,8 @@ public class LibassJNI {
    * Sets the storage size for the ASS_Renderer.
    *
    * @param assRendererPtr The pointer to the native ASS_Renderer instance.
-   * @param width The width of the storage in pixels.
-   * @param height The height of the storage in pixels.
+   * @param width          The width of the storage in pixels.
+   * @param height         The height of the storage in pixels.
    */
   private native void assSetStorageSize(long assRendererPtr, int width, int height);
 
@@ -281,23 +284,25 @@ public class LibassJNI {
    * Process a chunk of subtitle stream format
    *
    * @param assTrackPtr The pointer to the native ASS_Track instance.
-   * @param eventData The ass subtitle event.
-   * @param offset The index in {@code eventData} to start reading from (inclusive).
-   * @param length The number of bytes to read from {@code eventData}.
-   * @param timecode The timestamp in milliseconds.
-   * @param duration The duration of the event.
+   * @param eventData   The ass subtitle event.
+   * @param offset      The index in {@code eventData} to start reading from (inclusive).
+   * @param length      The number of bytes to read from {@code eventData}.
+   * @param timecode    The timestamp in milliseconds.
+   * @param duration    The duration of the event.
    */
-  private native void assProcessChunk(long assTrackPtr, byte[] eventData, int offset, int length, long timecode, long duration);
+  private native void assProcessChunk(long assTrackPtr, byte[] eventData, int offset, int length,
+      long timecode, long duration);
 
 
-  private native AssRenderResult renderFrameNative(long assRendererPtr, long assTrackPtr, int frame_width, int frame_height, long timeMs);
+  private native AssRenderResult assRenderFrame(long assRendererPtr, long assTrackPtr,
+      int frame_width, int frame_height, long timeMs);
 
 
   /**
    * Processes codec private data (subtitle headers) for the ASS_Track.
    *
    * @param assTrackPtr The pointer to the native ASS_Track instance.
-   * @param data The codec private data bytes.
+   * @param data        The codec private data bytes.
    */
   private native void assProcessCodecPrivate(long assTrackPtr, byte[] data);
 }

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -42,162 +42,8 @@ void libass_msg_callback(int level, const char *fmt, va_list args, void *data) {
   }
 }
 
-// Lit un fichier depuis les assets Android
-std::unique_ptr<char[]>
-read_asset_file(AAssetManager *assetManager, const char *filename, int &length) {
-  // Ouverture de l'asset avec gestion automatique de fermeture
-  std::unique_ptr<AAsset, decltype(&AAsset_close)> asset(
-      AAssetManager_open(assetManager, filename, AASSET_MODE_BUFFER),
-      AAsset_close
-  );
-
-  if (!asset) {
-    __android_log_print(ANDROID_LOG_ERROR, "TRACKERS", "Failed to open asset: %s", filename);
-    return nullptr;
-  }
-
-  // Lecture de contenu dans un buffer
-  length = AAsset_getLength(asset.get());
-  std::unique_ptr<char[]> buffer = std::make_unique<char[]>(length + 1);
-  AAsset_read(asset.get(), buffer.get(), length);
-
-  return buffer;
-}
-
-// Méthode JNI de démonstration
-extern "C" JNIEXPORT jstring JNICALL
-Java_com_example_prototypelibass_MainActivity_stringFromJNI(
-    JNIEnv *env,
-    jobject /* this */) {
-  std::string hello = "Hello from C++";
-
-  // Initialisation minimale de libass pour vérifier la version
-  ASS_Library *lib = ass_library_init();
-  int version = ass_library_version();
-  __android_log_print(ANDROID_LOG_DEBUG, "TRACKERS", "Print la version de libass 0x%x", version);
-  ass_library_done(lib);
-
-  return env->NewStringUTF(hello.c_str());
-}
-
-// Méthode principale de rendu des sous-titres
-extern "C"
-JNIEXPORT jobject JNICALL
-Java_com_example_prototypelibass_MainActivity_renderSubtitleFrame(
-    JNIEnv *env,
-    jobject thiz,
-    jobject asset_manager,
-    jint screenWidth,
-    jint screenHeight,
-    jint timestamp
-) {
-  // Récupération de l'AssetManager natif
-  AAssetManager *g_assetManager = AAssetManager_fromJava(env, asset_manager);
-
-  // Lire le fichier de sous-titres et de police avec la fonction générique
-  int subtitleLength, fontLength;
-  auto subtitleBuffer = read_asset_file(g_assetManager, "subtitle.ass", subtitleLength);
-  auto fontBuffer = read_asset_file(g_assetManager, "C059-Roman.otf", fontLength);
-  if (!subtitleBuffer || !fontBuffer) return nullptr;
-
-  // Initialisation de libass avec gestion automatique de mémoire
-  std::unique_ptr<ASS_Library, decltype(&ass_library_done)> lib(
-      ass_library_init(),
-      ass_library_done
-  );
-  if (!lib) {
-    __android_log_print(ANDROID_LOG_ERROR, "TRACKERS", "ass_library_init failed");
-    return nullptr;
-  }
-
-  ass_set_message_cb(lib.get(), libass_msg_callback, nullptr);
-
-  // Création du renderer
-  std::unique_ptr<ASS_Renderer, decltype(&ass_renderer_done)> renderer(
-      ass_renderer_init(lib.get()),
-      ass_renderer_done
-  );
-  if (!renderer) {
-    __android_log_print(ANDROID_LOG_ERROR, "TRACKERS", "ass_renderer_init failed");
-    return nullptr;
-  }
-
-  // Configuration du renderer
-  ass_set_storage_size(renderer.get(), screenWidth, screenHeight);
-  ass_set_frame_size(renderer.get(), screenWidth, screenHeight);
-  ass_set_fonts(renderer.get(), nullptr, nullptr, ASS_FONTPROVIDER_AUTODETECT, nullptr, true);
-  ass_add_font(lib.get(), "C059-Roman.otf", fontBuffer.get(), fontLength);
-
-  // Chargement de la piste de sous-titres
-  std::unique_ptr<ASS_Track, decltype(&ass_free_track)> track(
-      ass_read_memory(lib.get(), subtitleBuffer.get(), subtitleLength, nullptr),
-      ass_free_track
-  );
-  if (!track) {
-    __android_log_print(ANDROID_LOG_ERROR, "TRACKERS", "ass_read_memory failed");
-    return nullptr;
-  }
-
-  // Rendu de l'image à un timestamp donné
-  ASS_Image *ass_image = ass_render_frame(renderer.get(), track.get(), timestamp, nullptr);
-  if (!ass_image) {
-    __android_log_print(ANDROID_LOG_ERROR, "SUBTITLE_RENDER", "No subtitle image rendered");
-    return nullptr;
-  }
-
-  // Création d'un Bitmap Android via JNI
-  jclass bitmapClass = env->FindClass("android/graphics/Bitmap");
-  jmethodID createBitmapMethod = env->GetStaticMethodID(
-      bitmapClass,
-      "createBitmap",
-      "(IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;"
-  );
-
-  // Création d'un Bitmap ARGB_8888
-  jobject bitmap = env->CallStaticObjectMethod(
-      bitmapClass,
-      createBitmapMethod,
-      screenWidth,
-      screenHeight,
-      env->GetStaticObjectField(
-          env->FindClass("android/graphics/Bitmap$Config"),
-          env->GetStaticFieldID(env->FindClass("android/graphics/Bitmap$Config"),
-                                "ARGB_8888", "Landroid/graphics/Bitmap$Config;")
-      )
-  );
-
-  // Accès direct aux pixels du Bitmap
-  AndroidBitmapInfo bitmapInfo;
-  void *pixels = nullptr;
-  if (AndroidBitmap_getInfo(env, bitmap, &bitmapInfo) < 0 ||
-      AndroidBitmap_lockPixels(env, bitmap, &pixels) < 0) {
-    __android_log_print(ANDROID_LOG_ERROR, "SUBTITLE_RENDER", "Unable to lock bitmap pixels");
-    return nullptr;
-  }
-
-  // Nettoyage du buffer
-  memset(pixels, 0, bitmapInfo.stride * bitmapInfo.height);
-
-  // Dessin de toutes les composantes du sous-titre
-  for (ASS_Image *img = ass_image; img; img = img->next) {
-    uint8_t *dst = reinterpret_cast<uint8_t *>(pixels) +
-        img->dst_y * bitmapInfo.stride + // Décalage vertical
-        img->dst_x * 4;                  // Décalage horizontal (4 bytes/pixel)
-
-    draw_ass_rgba(dst, (ptrdiff_t) bitmapInfo.stride, img->bitmap, img->stride, img->w, img->h,
-                  img->color);
-  }
-
-  AndroidBitmap_unlockPixels(env, bitmap);
-
-  return bitmap;
-}
-
 // Function to initialize the ASS_Library
-extern "C"
-JNIEXPORT jlong JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_initAssLibrary(JNIEnv *env, jclass thiz) {
-  // Initialize the ASS_Library
+LIBASS_FUNC(jlong, initAssLibrary) {
   ASS_Library *library = ass_library_init();
   if (!library) {
     LOGE("Failed to initialize ASS_Library");
@@ -207,15 +53,10 @@ Java_androidx_media3_decoder_ass_LibassJNI_initAssLibrary(JNIEnv *env, jclass th
 
   ass_set_message_cb(library, libass_msg_callback, nullptr);
   return reinterpret_cast<jlong>(library);
-
 }
 
 // Destroy ASS_Library
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_destroyAssLibrary(JNIEnv *env,
-                                                             jclass clazz,
-                                                             jlong ass_library_ptr) {
+LIBASS_FUNC(void, destroyAssLibrary, jlong ass_library_ptr) {
   ASS_Library *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (library) {
     ass_library_done(library);
@@ -226,16 +67,7 @@ Java_androidx_media3_decoder_ass_LibassJNI_destroyAssLibrary(JNIEnv *env,
 }
 
 // add fonts to the library
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_addFont(
-    JNIEnv *env,
-    jobject thiz,
-    jlong ass_library_ptr,
-    jstring font_name,
-    jbyteArray font_data
-) {
-  // Convert jlong back to ASS_Library pointer
+LIBASS_FUNC(void, addFont, jlong ass_library_ptr, jstring font_name, jbyteArray font_data) {
   ASS_Library *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (!library) {
     LOGE("ASS_Library pointer is null");
@@ -268,16 +100,9 @@ Java_androidx_media3_decoder_ass_LibassJNI_addFont(
   env->ReleaseByteArrayElements(font_data, data, 0);
 }
 
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_processChunkNative(JNIEnv *env,
-                                                              jobject thiz,
-                                                              jlong track,
-                                                              jbyteArray eventData,
-                                                              jint offset,
-                                                              jint length,
-                                                              jlong timecode,
-                                                              jlong duration) {
+// Prepare data for processChunk
+LIBASS_FUNC(void, processChunkNative, jlong track, jbyteArray eventData,
+            jint offset, jint length, jlong timecode, jlong duration) {
   jbyte *data = env->GetByteArrayElements(eventData, nullptr);
   if (!data) {
     LOGE("Failed to get data");
@@ -290,19 +115,8 @@ Java_androidx_media3_decoder_ass_LibassJNI_processChunkNative(JNIEnv *env,
 }
 
 
-/**
- * Initializes the ASS_Renderer instance.
- *
- * @param env The JNI environment pointer.
- * @param thiz The Java object calling this function.
- * @param ass_library_ptr The pointer to the ASS_Library instance.
- * @return The pointer to the initialized ASS_Renderer instance, or 0 if initialization fails.
- */
-extern "C"
-JNIEXPORT jlong JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_initAssRenderer(JNIEnv *env,
-                                                           jobject thiz,
-                                                           jlong ass_library_ptr) {
+// Initialize the ASS_Renderer
+LIBASS_FUNC(jlong, initAssRenderer, jlong ass_library_ptr) {
   ASS_Library *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (!library) {
     LOGE("ASS_Library pointer is null during renderer initialization");
@@ -315,25 +129,14 @@ Java_androidx_media3_decoder_ass_LibassJNI_initAssRenderer(JNIEnv *env,
     return NULL;
   }
 
-  // Basic configuration of the renderer
   ass_set_fonts(renderer, NULL, NULL, ASS_FONTPROVIDER_AUTODETECT, NULL, 1);
-
   LOGD("ASS_Renderer initialized successfully");
   return reinterpret_cast<jlong>(renderer);
 }
 
-/**
- * Destroys the ASS_Renderer instance.
- *
- * @param env The JNI environment pointer.
- * @param thiz The Java object calling this function.
- * @param ass_renderer_ptr The pointer to the ASS_Renderer instance.
- */
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_destroyAssRenderer(JNIEnv *env,
-                                                              jobject thiz,
-                                                              jlong ass_renderer_ptr) {
+
+// Destroy Ass Renderer instance
+LIBASS_FUNC(void, destroyAssRenderer, jlong ass_renderer_ptr) {
   ASS_Renderer *renderer = reinterpret_cast<ASS_Renderer *>(ass_renderer_ptr);
   if (renderer) {
     ass_renderer_done(renderer);
@@ -343,26 +146,10 @@ Java_androidx_media3_decoder_ass_LibassJNI_destroyAssRenderer(JNIEnv *env,
   }
 }
 
-/**
- * Sets the frame size for the ASS_Renderer.
- *
- * @param env The JNI environment pointer.
- * @param thiz The Java object calling this function.
- * @param ass_renderer_ptr The pointer to the ASS_Renderer instance.
- * @param width The width of the frame in pixels.
- * @param height The height of the frame in pixels.
- */
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_setFrameSizeNative(JNIEnv *env,
-                                                              jobject thiz,
-                                                              jlong ass_renderer_ptr,
-                                                              jint width,
-                                                              jint height) {
+// Sets the frame size for the ASS_Renderer.
+LIBASS_FUNC(void, setFrameSizeNative, jlong ass_renderer_ptr, jint width, jint height) {
   LOGD("setFrameSizeNative called with renderer=%p, width=%d, height=%d",
-       (void *) ass_renderer_ptr,
-       width,
-       height);
+       (void *) ass_renderer_ptr, width, height);
 
   ASS_Renderer *renderer = reinterpret_cast<ASS_Renderer *>(ass_renderer_ptr);
   if (!renderer) {
@@ -375,22 +162,9 @@ Java_androidx_media3_decoder_ass_LibassJNI_setFrameSizeNative(JNIEnv *env,
   LOGD("ass_set_frame_size completed successfully");
 }
 
-/**
- * Sets the storage size for the ASS_Renderer.
- *
- * @param env The JNI environment pointer.
- * @param thiz The Java object calling this function.
- * @param ass_renderer_ptr The pointer to the ASS_Renderer instance.
- * @param width The width of the storage in pixels.
- * @param height The height of the storage in pixels.
- */
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_setStorageSizeNative(JNIEnv *env,
-                                                                jobject thiz,
-                                                                jlong ass_renderer_ptr,
-                                                                jint width,
-                                                                jint height) {
+
+// Sets the storage size for the ASS_Renderer.
+LIBASS_FUNC(void, setStorageSizeNative, jlong ass_renderer_ptr, jint width, jint height) {
   ASS_Renderer *renderer = reinterpret_cast<ASS_Renderer *>(ass_renderer_ptr);
   if (!renderer) {
     LOGE("ASS_Renderer pointer is null when setting storage size");
@@ -401,19 +175,8 @@ Java_androidx_media3_decoder_ass_LibassJNI_setStorageSizeNative(JNIEnv *env,
   LOGD("Storage size set to %d x %d", width, height);
 }
 
-/**
- * Creates a new ASS_Track.
- *
- * @param env The JNI environment pointer.
- * @param thiz The Java object calling this function.
- * @param ass_library_ptr The pointer to the ASS_Library instance.
- * @return The pointer to the created ASS_Track instance, or 0 if creation fails.
- */
-extern "C"
-JNIEXPORT jlong JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_createTrackNative(JNIEnv *env,
-                                                             jobject thiz,
-                                                             jlong ass_library_ptr) {
+// Creates new ASS_Track
+LIBASS_FUNC(jlong, createTrackNative, jlong ass_library_ptr) {
   auto *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (!library) {
     LOGE("ASS_Library pointer is null when creating track");
@@ -430,18 +193,9 @@ Java_androidx_media3_decoder_ass_LibassJNI_createTrackNative(JNIEnv *env,
   return reinterpret_cast<jlong>(track);
 }
 
-/**
- * Destroys the ASS_Track instance.
- *
- * @param env The JNI environment pointer.
- * @param thiz The Java object calling this function.
- * @param ass_track_ptr The pointer to the ASS_Track instance.
- */
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_destroyTrackNative(JNIEnv *env,
-                                                              jobject thiz,
-                                                              jlong ass_track_ptr) {
+
+// Destroys the ASS_Track instance.
+LIBASS_FUNC(void, destroyTrackNative, jlong ass_track_ptr) {
   ASS_Track *track = reinterpret_cast<ASS_Track *>(ass_track_ptr);
   if (track) {
     ass_free_track(track);
@@ -451,20 +205,8 @@ Java_androidx_media3_decoder_ass_LibassJNI_destroyTrackNative(JNIEnv *env,
   }
 }
 
-/**
- * Processes codec private data from a subtitle stream.
- *
- * @param env The JNI environment pointer.
- * @param thiz The Java object calling this function.
- * @param ass_track_ptr The pointer to the ASS_Track instance.
- * @param data The codec private data.
- */
-extern "C"
-JNIEXPORT void JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_processCodecPrivateNative(JNIEnv *env,
-                                                                     jobject thiz,
-                                                                     jlong ass_track_ptr,
-                                                                     jbyteArray data) {
+// Process codec private data
+LIBASS_FUNC(void, processCodecPrivateNative, jlong ass_track_ptr, jbyteArray data) {
   ASS_Track *track = reinterpret_cast<ASS_Track *>(ass_track_ptr);
   if (!track) {
     LOGE("ASS_Track pointer is null when processing codec private data");
@@ -484,7 +226,6 @@ Java_androidx_media3_decoder_ass_LibassJNI_processCodecPrivateNative(JNIEnv *env
 
   // Release the JNI resources
   env->ReleaseByteArrayElements(data, data_bytes, JNI_OK);
-
   LOGD("Codec private data processed successfully");
 }
 
@@ -493,19 +234,7 @@ Java_androidx_media3_decoder_ass_LibassJNI_processCodecPrivateNative(JNIEnv *env
  * Renders a frame for a specific track at the given timestamp.
  * This implementation includes diagnostic logging to help debug rendering issues.
  */
-extern "C"
-JNIEXPORT jobject JNICALL
-Java_androidx_media3_decoder_ass_LibassJNI_renderFrameNative(
-    JNIEnv *env,
-    jobject thiz,
-    jlong ass_renderer_ptr,
-    jlong ass_track_ptr,
-    jint frame_width,
-    jint frame_height,
-    jlong time_ms) {
-  jclass resultClass = env->FindClass("androidx/media3/decoder/ass/AssRenderResult");
-  jmethodID resultConstructor = env->GetMethodID(resultClass, "<init>", "(Landroid/graphics/Bitmap;Z)V");
-
+LIBASS_FUNC(jobject, renderFrameNative, jlong ass_renderer_ptr, jlong ass_track_ptr, jint frame_width, jint frame_height, jlong time_ms) {
   ASS_Renderer *renderer = reinterpret_cast<ASS_Renderer *>(ass_renderer_ptr);
   ASS_Track *track = reinterpret_cast<ASS_Track *>(ass_track_ptr);
 
@@ -543,7 +272,6 @@ Java_androidx_media3_decoder_ass_LibassJNI_renderFrameNative(
       )
   );
 
-  // Lock pixels for direct manipulation
   AndroidBitmapInfo bitmapInfo;
   void *pixels = nullptr;
   if (AndroidBitmap_getInfo(env, bitmap, &bitmapInfo) != ANDROID_BITMAP_RESULT_SUCCESS ||
@@ -552,22 +280,15 @@ Java_androidx_media3_decoder_ass_LibassJNI_renderFrameNative(
     return env->NewObject(resultClass, resultConstructor, (jobject) nullptr, changedSinceLastCall);
   }
 
-
-
-  // Render all subtitle image components
   for (ASS_Image *current = img; current; current = current->next) {
-    // Skip images with zero dimensions
     if (current->w <= 0 || current->h <= 0) {
       continue;
     }
 
-
-    // Calculate destination pointer in bitmap
     uint8_t *dst = reinterpret_cast<uint8_t *>(pixels) +
-        current->dst_y * bitmapInfo.stride +  // Vertical offset
-        current->dst_x * 4;                   // Horizontal offset (4 bytes per pixel)
+        current->dst_y * bitmapInfo.stride + // Vertical offset
+        current->dst_x * 4;                  // Horizontal offset (4 bytes per pixel)
 
-    // Render the ASS image component onto the bitmap
     draw_ass_rgba(
         dst,
         bitmapInfo.stride,
@@ -579,7 +300,6 @@ Java_androidx_media3_decoder_ass_LibassJNI_renderFrameNative(
     );
   }
 
-  // Unlock the bitmap
   AndroidBitmap_unlockPixels(env, bitmap);
 
   return env->NewObject(resultClass, resultConstructor, bitmap, changedSinceLastCall);

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -11,6 +11,13 @@
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 
+#define LIBASS_FUNC(RETURN_TYPE, NAME, ...)                                \
+  extern "C" {                                                              \
+  JNIEXPORT RETURN_TYPE Java_androidx_media3_decoder_ass_LibassJNI_##NAME( \
+      JNIEnv* env, jobject thiz, ##__VA_ARGS__);                            \
+  }                                                                         \
+  JNIEXPORT RETURN_TYPE Java_androidx_media3_decoder_ass_LibassJNI_##NAME( \
+      JNIEnv* env, jobject thiz, ##__VA_ARGS__)
 
 static void draw_ass_rgba(uint8_t *dst, ptrdiff_t dst_stride,
                           const uint8_t *src, ptrdiff_t src_stride,
@@ -234,7 +241,10 @@ LIBASS_FUNC(void, assProcessCodecPrivate, jlong ass_track_ptr, jbyteArray data) 
  * Renders a frame for a specific track at the given timestamp.
  * This implementation includes diagnostic logging to help debug rendering issues.
  */
-LIBASS_FUNC(jobject, renderFrameNative, jlong ass_renderer_ptr, jlong ass_track_ptr, jint frame_width, jint frame_height, jlong time_ms) {
+LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr, jint frame_width, jint frame_height, jlong time_ms) {
+  jclass resultClass = env->FindClass("androidx/media3/decoder/ass/AssRenderResult");
+  jmethodID resultConstructor = env->GetMethodID(resultClass, "<init>", "(Landroid/graphics/Bitmap;Z)V");
+
   ASS_Renderer *renderer = reinterpret_cast<ASS_Renderer *>(ass_renderer_ptr);
   ASS_Track *track = reinterpret_cast<ASS_Track *>(ass_track_ptr);
 

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -43,7 +43,7 @@ void libass_msg_callback(int level, const char *fmt, va_list args, void *data) {
 }
 
 // Function to initialize the ASS_Library
-LIBASS_FUNC(jlong, initAssLibrary) {
+LIBASS_FUNC(jlong, assLibraryInit) {
   ASS_Library *library = ass_library_init();
   if (!library) {
     LOGE("Failed to initialize ASS_Library");
@@ -56,7 +56,7 @@ LIBASS_FUNC(jlong, initAssLibrary) {
 }
 
 // Destroy ASS_Library
-LIBASS_FUNC(void, destroyAssLibrary, jlong ass_library_ptr) {
+LIBASS_FUNC(void, assLibraryDone, jlong ass_library_ptr) {
   ASS_Library *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (library) {
     ass_library_done(library);
@@ -67,7 +67,7 @@ LIBASS_FUNC(void, destroyAssLibrary, jlong ass_library_ptr) {
 }
 
 // add fonts to the library
-LIBASS_FUNC(void, addFont, jlong ass_library_ptr, jstring font_name, jbyteArray font_data) {
+LIBASS_FUNC(void, assAddFont, jlong ass_library_ptr, jstring font_name, jbyteArray font_data) {
   ASS_Library *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (!library) {
     LOGE("ASS_Library pointer is null");
@@ -101,7 +101,7 @@ LIBASS_FUNC(void, addFont, jlong ass_library_ptr, jstring font_name, jbyteArray 
 }
 
 // Prepare data for processChunk
-LIBASS_FUNC(void, processChunkNative, jlong track, jbyteArray eventData,
+LIBASS_FUNC(void, assProcessChunk, jlong track, jbyteArray eventData,
             jint offset, jint length, jlong timecode, jlong duration) {
   jbyte *data = env->GetByteArrayElements(eventData, nullptr);
   if (!data) {
@@ -116,7 +116,7 @@ LIBASS_FUNC(void, processChunkNative, jlong track, jbyteArray eventData,
 
 
 // Initialize the ASS_Renderer
-LIBASS_FUNC(jlong, initAssRenderer, jlong ass_library_ptr) {
+LIBASS_FUNC(jlong, assRendererInit, jlong ass_library_ptr) {
   ASS_Library *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (!library) {
     LOGE("ASS_Library pointer is null during renderer initialization");
@@ -136,7 +136,7 @@ LIBASS_FUNC(jlong, initAssRenderer, jlong ass_library_ptr) {
 
 
 // Destroy Ass Renderer instance
-LIBASS_FUNC(void, destroyAssRenderer, jlong ass_renderer_ptr) {
+LIBASS_FUNC(void, assRendererDone, jlong ass_renderer_ptr) {
   ASS_Renderer *renderer = reinterpret_cast<ASS_Renderer *>(ass_renderer_ptr);
   if (renderer) {
     ass_renderer_done(renderer);
@@ -147,7 +147,7 @@ LIBASS_FUNC(void, destroyAssRenderer, jlong ass_renderer_ptr) {
 }
 
 // Sets the frame size for the ASS_Renderer.
-LIBASS_FUNC(void, setFrameSizeNative, jlong ass_renderer_ptr, jint width, jint height) {
+LIBASS_FUNC(void, assSetFrameSize, jlong ass_renderer_ptr, jint width, jint height) {
   LOGD("setFrameSizeNative called with renderer=%p, width=%d, height=%d",
        (void *) ass_renderer_ptr, width, height);
 
@@ -164,7 +164,7 @@ LIBASS_FUNC(void, setFrameSizeNative, jlong ass_renderer_ptr, jint width, jint h
 
 
 // Sets the storage size for the ASS_Renderer.
-LIBASS_FUNC(void, setStorageSizeNative, jlong ass_renderer_ptr, jint width, jint height) {
+LIBASS_FUNC(void, assSetStorageSize, jlong ass_renderer_ptr, jint width, jint height) {
   ASS_Renderer *renderer = reinterpret_cast<ASS_Renderer *>(ass_renderer_ptr);
   if (!renderer) {
     LOGE("ASS_Renderer pointer is null when setting storage size");
@@ -176,7 +176,7 @@ LIBASS_FUNC(void, setStorageSizeNative, jlong ass_renderer_ptr, jint width, jint
 }
 
 // Creates new ASS_Track
-LIBASS_FUNC(jlong, createTrackNative, jlong ass_library_ptr) {
+LIBASS_FUNC(jlong, assNewTrack, jlong ass_library_ptr) {
   auto *library = reinterpret_cast<ASS_Library *>(ass_library_ptr);
   if (!library) {
     LOGE("ASS_Library pointer is null when creating track");
@@ -195,7 +195,7 @@ LIBASS_FUNC(jlong, createTrackNative, jlong ass_library_ptr) {
 
 
 // Destroys the ASS_Track instance.
-LIBASS_FUNC(void, destroyTrackNative, jlong ass_track_ptr) {
+LIBASS_FUNC(void, assFreeTrack, jlong ass_track_ptr) {
   ASS_Track *track = reinterpret_cast<ASS_Track *>(ass_track_ptr);
   if (track) {
     ass_free_track(track);
@@ -206,7 +206,7 @@ LIBASS_FUNC(void, destroyTrackNative, jlong ass_track_ptr) {
 }
 
 // Process codec private data
-LIBASS_FUNC(void, processCodecPrivateNative, jlong ass_track_ptr, jbyteArray data) {
+LIBASS_FUNC(void, assProcessCodecPrivate, jlong ass_track_ptr, jbyteArray data) {
   ASS_Track *track = reinterpret_cast<ASS_Track *>(ass_track_ptr);
   if (!track) {
     LOGE("ASS_Track pointer is null when processing codec private data");


### PR DESCRIPTION
IMPORTANT: MERGER #9 AVANT
~~mes changements sont uniquement dans https://github.com/moi15moi/media/pull/10/commits/aad43947bd68aa23bb05ae50aa238fa38ed58e54 et https://github.com/moi15moi/media/pull/10/commits/c510757cbc452fb8308a087f80592c2dba44424f~~

# Les autres librairies natives ne nomment pas les noms des méthodes comme nous.
Ils utilisent ceci LIBRARY_FUNC et DECODER_FUNC:

https://github.com/moi15moi/media/blob/ae664ed062967283d8241f24e9db8a3317908d53/libraries/decoder_vp9/src/main/jni/vpx_jni.cc#L41-L55
https://github.com/moi15moi/media/blob/ae664ed062967283d8241f24e9db8a3317908d53/libraries/decoder_vp9/src/main/jni/vpx_jni.cc#L700-L702

Les changements fait sont similaire à leur implémentation.