### PR TITLE
Effectuer le "VSFilter mangled colors"

### DIFF
--- a/libraries/decoder_ass/build.gradle
+++ b/libraries/decoder_ass/build.gradle
@@ -41,12 +41,6 @@ dependencies {
     implementation project(modulePrefix + 'lib-exoplayer')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
-    compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion
     androidTestImplementation project(modulePrefix + 'test-utils')
     androidTestImplementation 'androidx.test:runner:' + androidxTestRunnerVersion
-    testImplementation 'androidx.test:core:' + androidxTestCoreVersion
-    testImplementation 'androidx.test.ext:junit:' + androidxTestJUnitVersion
-    testImplementation project(modulePrefix + 'test-utils')
-    testImplementation project(modulePrefix + 'test-data')
-    testImplementation 'org.robolectric:robolectric:' + robolectricVersion
 }

--- a/libraries/decoder_ass/build.gradle
+++ b/libraries/decoder_ass/build.gradle
@@ -42,6 +42,11 @@ dependencies {
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
     compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion
+    androidTestImplementation project(modulePrefix + 'test-utils')
+    androidTestImplementation 'androidx.test:runner:' + androidxTestRunnerVersion
+    testImplementation 'androidx.test:core:' + androidxTestCoreVersion
+    testImplementation 'androidx.test.ext:junit:' + androidxTestJUnitVersion
     testImplementation project(modulePrefix + 'test-utils')
+    testImplementation project(modulePrefix + 'test-data')
     testImplementation 'org.robolectric:robolectric:' + robolectricVersion
 }

--- a/libraries/decoder_ass/src/androidTest/AndroidManifest.xml
+++ b/libraries/decoder_ass/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2025 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  package="androidx.media3.decoder.ass.test">
+
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+  <uses-sdk/>
+
+  <application
+    android:allowBackup="false"
+    tools:ignore="MissingApplicationIcon,HardcodedDebugMode"/>
+
+  <instrumentation
+    android:targetPackage="androidx.media3.decoder.ass.test"
+    android:name="androidx.test.runner.AndroidJUnitRunner"/>
+
+</manifest>

--- a/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
+++ b/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.decoder.ass;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.graphics.Color;
+import androidx.media3.common.C;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Unit test for {@link LibassJNITest}.
+ */
+@RunWith(AndroidJUnit4.class)
+public class LibassJNITest {
+
+  private String buildHeader(String ycbcrMatrix) {
+    return "[Script Info]\n" +
+        "ScriptType: v4.00+\n" +
+        "WrapStyle: 0\n" +
+        "ScaledBorderAndShadow: yes\n" +
+        "YCbCr Matrix: " + ycbcrMatrix + "\n" +
+        "PlayResX: 640\n" +
+        "PlayResY: 480\n" +
+        "\n" +
+        "[V4+ Styles]\n" +
+        "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n" +
+        "Style: Default,Arial,48,&H00000000,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,0,0,2,0,0,0,1\n";
+  }
+
+  private LibassJNI setupLibassJNI(String ycbcrMatrix, int videoColorSpace, int videoColorRange,
+      int initialRed, int initialGreen, int initialBlue) {
+    LibassJNI libassJNI = new LibassJNI();
+    libassJNI.setFrameSize(640, 480);
+    libassJNI.setStorageSize(640, 480);
+    libassJNI.setVideoColorSpace(videoColorSpace);
+    libassJNI.setVideoColorRange(videoColorRange);
+    libassJNI.createTrack("0");
+
+    libassJNI.processCodecPrivate("0", buildHeader(ycbcrMatrix).getBytes(StandardCharsets.UTF_8));
+
+    String colorTag = "\\c&H" + String.format("%02x", initialBlue) + String.format("%02x", initialGreen) + String.format("%02x", initialRed) + "&";
+    String line = "Dialogue: 0:00:00:00,0:00:05:00,1,0,Default,,0,0,0,,{\\an7\\pos(0,0)\\p1" + colorTag + "}m 0 0 l 640 0 640 480 0 480";
+    byte[] line_bytes = line.getBytes(StandardCharsets.UTF_8);
+    ByteBuffer line_buffer = ByteBuffer.wrap(line_bytes);
+    libassJNI.prepareProcessChunk(line_buffer.array(), line_buffer.position(), line_buffer.remaining(), 0, "0");
+    return libassJNI;
+  }
+
+  private void assertCenterPixel(AssRenderResult result, int expectedRed, int expectedGreen, int expectedBlue) {
+    assertThat(result.changedSinceLastCall).isTrue();
+    assertThat(result.bitmap).isNotNull();
+    int color = result.bitmap.getPixel(640 / 2, 480 / 2);
+    assertThat(Color.red(color)).isEqualTo(expectedRed);
+    assertThat(Color.green(color)).isEqualTo(expectedGreen);
+    assertThat(Color.blue(color)).isEqualTo(expectedBlue);
+    assertThat(Color.alpha(color)).isEqualTo(255);
+  }
+
+  @Test
+  public void renderFrame_TV601_to_TV709() {
+    LibassJNI libassJNI = setupLibassJNI("TV.601", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 155, 104, 78);
+  }
+
+  @Test
+  public void renderFrame_TV601_to_PC709() {
+    LibassJNI libassJNI = setupLibassJNI("TV.601", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150, 100, 80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 150, 105, 83);
+  }
+
+  @Test
+  public void renderFrame_TV709_to_TV601() {
+    LibassJNI libassJNI = setupLibassJNI("TV.709", C.COLOR_SPACE_BT601, C.COLOR_RANGE_LIMITED, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 146, 96, 81);
+  }
+
+  @Test
+  public void renderFrame_TV709_to_PC601() {
+    LibassJNI libassJNI = setupLibassJNI("TV.709", C.COLOR_SPACE_BT601, C.COLOR_RANGE_FULL, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 142, 98, 85);
+  }
+
+  @Test
+  public void renderFrame_TVFCC_to_TV709() {
+    LibassJNI libassJNI = setupLibassJNI("TV.FCC", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 155, 104, 79);
+  }
+
+  @Test
+  public void renderFrame_TVFCC_to_PC709() {
+    LibassJNI libassJNI = setupLibassJNI("TV.FCC", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 150, 105, 83);
+  }
+
+  @Test
+  public void renderFrame_TV240M_to_TV709() {
+    LibassJNI libassJNI = setupLibassJNI("TV.240M", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 150, 100, 80);
+  }
+
+  @Test
+  public void renderFrame_TV240M_to_PC709() {
+    LibassJNI libassJNI = setupLibassJNI("TV.240M", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 146, 101, 84);
+  }
+}

--- a/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
+++ b/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
@@ -75,70 +75,70 @@ public class LibassJNITest {
   }
 
   @Test
-  public void renderFrame_TV601_to_TV709() {
+  public void renderFrameTV601ToTV709() {
     LibassJNI libassJNI = setupLibassJNI("TV.601", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 155, 104, 78);
   }
 
   @Test
-  public void renderFrame_TV601_to_PC709() {
+  public void renderFrameTV601ToPC709() {
     LibassJNI libassJNI = setupLibassJNI("TV.601", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150, 100, 80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 150, 105, 83);
   }
 
   @Test
-  public void renderFrame_TV709_to_TV601() {
+  public void renderFrameTV709ToTV601() {
     LibassJNI libassJNI = setupLibassJNI("TV.709", C.COLOR_SPACE_BT601, C.COLOR_RANGE_LIMITED, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 146, 96, 81);
   }
 
   @Test
-  public void renderFrame_TV709_to_PC601() {
+  public void renderFrameTV709ToPC601() {
     LibassJNI libassJNI = setupLibassJNI("TV.709", C.COLOR_SPACE_BT601, C.COLOR_RANGE_FULL, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 142, 98, 85);
   }
 
   @Test
-  public void renderFrame_TVFCC_to_TV709() {
+  public void renderFrameTVFCCToTV709() {
     LibassJNI libassJNI = setupLibassJNI("TV.FCC", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 155, 104, 79);
   }
 
   @Test
-  public void renderFrame_TVFCC_to_PC709() {
+  public void renderFrameTVFCCToPC709() {
     LibassJNI libassJNI = setupLibassJNI("TV.FCC", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 150, 105, 83);
   }
 
   @Test
-  public void renderFrame_TV240M_to_TV709() {
+  public void renderFrameTV240MToTV709() {
     LibassJNI libassJNI = setupLibassJNI("TV.240M", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 150, 100, 80);
   }
 
   @Test
-  public void renderFrame_TV240M_to_PC709() {
+  public void renderFrameTV240MToPC709() {
     LibassJNI libassJNI = setupLibassJNI("TV.240M", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 146, 101, 84);
   }
 
   @Test
-  public void renderFrame_none() {
+  public void renderFrameNone() {
     LibassJNI libassJNI = setupLibassJNI("None", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 150,100,80);
   }
 
   @Test
-  public void renderFrame_no_ycbcr_matrix() {
+  public void renderFrameNoYcbcrMatrix() {
     LibassJNI libassJNI = setupLibassJNI(null, C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 155, 104, 78);

--- a/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
+++ b/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
@@ -50,8 +50,7 @@ public class LibassJNITest {
     LibassJNI libassJNI = new LibassJNI();
     libassJNI.setFrameSize(640, 480);
     libassJNI.setStorageSize(640, 480);
-    libassJNI.setVideoColorSpace(videoColorSpace);
-    libassJNI.setVideoColorRange(videoColorRange);
+    libassJNI.setVideoColorProperties(videoColorSpace, videoColorRange);
     libassJNI.createTrack("0");
 
     libassJNI.processCodecPrivate("0", buildHeader(ycbcrMatrix).getBytes(StandardCharsets.UTF_8));

--- a/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
+++ b/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
@@ -128,4 +128,11 @@ public class LibassJNITest {
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 146, 101, 84);
   }
+
+  @Test
+  public void renderFrame_no_ycbcr_matrix() {
+    LibassJNI libassJNI = setupLibassJNI("None", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 150,100,80);
+  }
 }

--- a/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
+++ b/libraries/decoder_ass/src/androidTest/java/androidx/media3/decoder/ass/LibassJNITest.java
@@ -18,6 +18,7 @@ package androidx.media3.decoder.ass;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.graphics.Color;
+import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.nio.ByteBuffer;
@@ -31,12 +32,12 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class LibassJNITest {
 
-  private String buildHeader(String ycbcrMatrix) {
+  private String buildHeader(@Nullable String ycbcrMatrix) {
     return "[Script Info]\n" +
         "ScriptType: v4.00+\n" +
         "WrapStyle: 0\n" +
         "ScaledBorderAndShadow: yes\n" +
-        "YCbCr Matrix: " + ycbcrMatrix + "\n" +
+        (ycbcrMatrix != null ? "YCbCr Matrix: " + ycbcrMatrix + "\n" : "") +
         "PlayResX: 640\n" +
         "PlayResY: 480\n" +
         "\n" +
@@ -45,7 +46,7 @@ public class LibassJNITest {
         "Style: Default,Arial,48,&H00000000,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,0,0,2,0,0,0,1\n";
   }
 
-  private LibassJNI setupLibassJNI(String ycbcrMatrix, int videoColorSpace, int videoColorRange,
+  private LibassJNI setupLibassJNI(@Nullable String ycbcrMatrix, int videoColorSpace, int videoColorRange,
       int initialRed, int initialGreen, int initialBlue) {
     LibassJNI libassJNI = new LibassJNI();
     libassJNI.setFrameSize(640, 480);
@@ -130,9 +131,16 @@ public class LibassJNITest {
   }
 
   @Test
-  public void renderFrame_no_ycbcr_matrix() {
-    LibassJNI libassJNI = setupLibassJNI("None", C.COLOR_SPACE_BT709, C.COLOR_RANGE_FULL, 150,100,80);
+  public void renderFrame_none() {
+    LibassJNI libassJNI = setupLibassJNI("None", C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
     AssRenderResult result = libassJNI.renderFrame("0", 0);
     assertCenterPixel(result, 150,100,80);
+  }
+
+  @Test
+  public void renderFrame_no_ycbcr_matrix() {
+    LibassJNI libassJNI = setupLibassJNI(null, C.COLOR_SPACE_BT709, C.COLOR_RANGE_LIMITED, 150,100,80);
+    AssRenderResult result = libassJNI.renderFrame("0", 0);
+    assertCenterPixel(result, 155, 104, 78);
   }
 }

--- a/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/AssRenderer.java
+++ b/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/AssRenderer.java
@@ -461,7 +461,9 @@ public final class AssRenderer extends BaseRenderer implements Callback {
 
       case MSG_EVENT_VIDEO_FORMAT_CHANGED:
         Format videoFormat = (Format) checkNotNull(message, "Video format message cannot be null");
-        if (videoFormat.colorInfo != null) {
+        if (videoFormat.colorInfo == null) {
+          libassJNI.setVideoColorProperties(Format.NO_VALUE, Format.NO_VALUE);
+        } else {
           libassJNI.setVideoColorProperties(videoFormat.colorInfo.colorSpace, videoFormat.colorInfo.colorRange);
         }
         break;

--- a/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/AssRenderer.java
+++ b/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/AssRenderer.java
@@ -462,8 +462,7 @@ public final class AssRenderer extends BaseRenderer implements Callback {
       case MSG_EVENT_VIDEO_FORMAT_CHANGED:
         Format videoFormat = (Format) checkNotNull(message, "Video format message cannot be null");
         if (videoFormat.colorInfo != null) {
-          libassJNI.setVideoColorSpace(videoFormat.colorInfo.colorSpace);
-          libassJNI.setVideoColorRange(videoFormat.colorInfo.colorRange);
+          libassJNI.setVideoColorProperties(videoFormat.colorInfo.colorSpace, videoFormat.colorInfo.colorRange);
         }
         break;
 

--- a/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/AssRenderer.java
+++ b/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/AssRenderer.java
@@ -460,12 +460,10 @@ public final class AssRenderer extends BaseRenderer implements Callback {
         break;
 
       case MSG_EVENT_VIDEO_FORMAT_CHANGED:
-        // TODO: Handle this case properly in the alpha blending
         Format videoFormat = (Format) checkNotNull(message, "Video format message cannot be null");
         if (videoFormat.colorInfo != null) {
-          Log.d(TAG, "videoFormat.colorInfo = " + videoFormat.colorInfo);
-        } else {
-          Log.d(TAG, "The video format does not have a defined color info.");
+          libassJNI.setVideoColorSpace(videoFormat.colorInfo.colorSpace);
+          libassJNI.setVideoColorRange(videoFormat.colorInfo.colorRange);
         }
         break;
 

--- a/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
+++ b/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
@@ -66,22 +66,14 @@ public class LibassJNI {
   }
 
   /**
-   * Sets the video color space
-   * that will be use for the alpha blending.
+   * Sets the video color space and color range
+   * that will be used for the alpha blending.
    *
    * @param videoColorSpace The video color space.
-   */
-  public void setVideoColorSpace(@C.ColorSpace int videoColorSpace) {
-    this.videoColorSpace = videoColorSpace;
-  }
-
-  /**
-   * Sets the video color range
-   * that will be use for the alpha blending.
-   *
    * @param videoColorRange The video color range.
    */
-  public void setVideoColorRange(@C.ColorRange int videoColorRange) {
+  public void setVideoColorProperties(@C.ColorSpace int videoColorSpace, @C.ColorRange int videoColorRange) {
+    this.videoColorSpace = videoColorSpace;
     this.videoColorRange = videoColorRange;
   }
 

--- a/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
+++ b/libraries/decoder_ass/src/main/java/androidx/media3/decoder/ass/LibassJNI.java
@@ -1,6 +1,8 @@
 package androidx.media3.decoder.ass;
 
 import androidx.annotation.Nullable;
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
 import androidx.media3.common.util.Log;
 import androidx.media3.extractor.text.ssa.SsaParser;
 import java.nio.charset.StandardCharsets;
@@ -19,6 +21,9 @@ public class LibassJNI {
   @Nullable
   private Integer frame_height = null;
 
+  private @C.ColorSpace int videoColorSpace;
+  private @C.ColorRange int videoColorRange;
+
   public LibassJNI() {
     if (!AssLibrary.isAvailable()) {
       throw new RuntimeException("Libass native library is not available");
@@ -33,6 +38,9 @@ public class LibassJNI {
     if (assRendererPtr == 0) {
       throw new RuntimeException("Failed to initialize ASS_Renderer");
     }
+
+    this.videoColorSpace = Format.NO_VALUE;
+    this.videoColorRange = Format.NO_VALUE;
   }
 
   /**
@@ -55,6 +63,26 @@ public class LibassJNI {
    */
   public void setStorageSize(int width, int height) {
     assSetStorageSize(assRendererPtr, width, height);
+  }
+
+  /**
+   * Sets the video color space
+   * that will be use for the alpha blending.
+   *
+   * @param videoColorSpace The video color space.
+   */
+  public void setVideoColorSpace(@C.ColorSpace int videoColorSpace) {
+    this.videoColorSpace = videoColorSpace;
+  }
+
+  /**
+   * Sets the video color range
+   * that will be use for the alpha blending.
+   *
+   * @param videoColorRange The video color range.
+   */
+  public void setVideoColorRange(@C.ColorRange int videoColorRange) {
+    this.videoColorRange = videoColorRange;
   }
 
   /**
@@ -174,7 +202,8 @@ public class LibassJNI {
     if (frame_width == null || frame_height == null) {
       throw new RuntimeException("Frame size has not been set");
     }
-    return assRenderFrame(assRendererPtr, trackPtr, frame_width, frame_height, timeMs);
+    return assRenderFrame(assRendererPtr, trackPtr, frame_width, frame_height, timeMs,
+        videoColorSpace, videoColorRange);
   }
 
   /**
@@ -295,7 +324,7 @@ public class LibassJNI {
 
 
   private native AssRenderResult assRenderFrame(long assRendererPtr, long assTrackPtr,
-      int frame_width, int frame_height, long timeMs);
+      int frame_width, int frame_height, long timeMs, int colorSpace, int colorRange);
 
 
   /**

--- a/libraries/decoder_ass/src/main/jni/CMakeLists.txt
+++ b/libraries/decoder_ass/src/main/jni/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
 
-# Enable C++11 features.
-set(CMAKE_CXX_STANDARD 14)
+# Enable C++17 features.
+set(CMAKE_CXX_STANDARD 17)
 
 # Define project name for your JNI module
 project(libassJNI C CXX)

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -485,8 +485,11 @@ LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr
       break;
   }
 
-  ColorSpace src_color_space = getColorSpace(src_color_space_enum);
+  ColorSpace src_color_space;
   ColorSpace dst_color_space = getColorSpace(dst_color_space_enum);
+  if (src_color_space_enum != ColorSpaceEnum::UNKNOWN) {
+    src_color_space = getColorSpace(src_color_space_enum);
+  }
 
   // Create an Android Bitmap
   jclass bitmapClass = env->FindClass("android/graphics/Bitmap");

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -1,7 +1,10 @@
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
 #include <android/log.h>
+#include <algorithm>
+#include <cmath>
 #include <jni.h>
+#include <optional>
 #include <string>
 #include <android/bitmap.h>
 #include "ass/ass.h"
@@ -19,22 +22,192 @@
   JNIEXPORT RETURN_TYPE Java_androidx_media3_decoder_ass_LibassJNI_##NAME( \
       JNIEnv* env, jobject thiz, ##__VA_ARGS__)
 
+
+class RGB {
+ public:
+  double r_prime, g_prime, b_prime;
+  uint8_t r, g, b;
+
+  explicit RGB(uint8_t r, uint8_t g, uint8_t b) {
+    this->r = r;
+    this->g = g;
+    this->b = b;
+
+    this->r_prime = this->r / 255.0;
+    this->g_prime = this->g / 255.0;
+    this->b_prime = this->b / 255.0;
+  }
+
+  explicit RGB(double r_prime, double g_prime, double b_prime) {
+    this->r_prime = r_prime;
+    this->g_prime = g_prime;
+    this->b_prime = b_prime;
+
+    this->r = std::lround(this->r_prime * 255.0);
+    this->g = std::lround(this->g_prime * 255.0);
+    this->b = std::lround(this->b_prime * 255.0);
+  }
+};
+
+struct YCbCr {
+  double y, cb, cr;
+};
+
+struct ColorSpace {
+  double kr, kg, kb;
+};
+
+enum class ColorSpaceEnum {
+  UNKNOWN,
+  BT601,
+  BT709,
+  FCC,
+  SMPTE_240M,
+  BT2020
+};
+
+// Must match https://developer.android.com/reference/androidx/media3/common/C.ColorSpace
+enum ColorSpaceMedia3 {
+  COLOR_SPACE_NO_VALUE = -1,
+  COLOR_SPACE_BT601 = 2,
+  COLOR_SPACE_BT709 = 1,
+  COLOR_SPACE_BT2020 = 6,
+};
+
+constexpr ColorSpaceEnum getColorSpaceFromMedia3ColorSpace(ColorSpaceMedia3 color_space) {
+  switch (color_space) {
+    case ColorSpaceMedia3::COLOR_SPACE_NO_VALUE:
+    case ColorSpaceMedia3::COLOR_SPACE_BT709:
+      return ColorSpaceEnum::BT709;
+    case ColorSpaceMedia3::COLOR_SPACE_BT601: return ColorSpaceEnum::BT601;
+    case ColorSpaceMedia3::COLOR_SPACE_BT2020: return ColorSpaceEnum::BT2020;
+    default: return ColorSpaceEnum::UNKNOWN;
+  }
+}
+
+constexpr ColorSpace getColorSpace(ColorSpaceEnum space) {
+  switch (space) {
+    case ColorSpaceEnum::BT601: return {0.299, 0.587, 0.114};
+    case ColorSpaceEnum::BT709: return {0.2126, 0.7152, 0.0722};
+    case ColorSpaceEnum::FCC: return {0.3, 0.59, 0.11};
+    case ColorSpaceEnum::SMPTE_240M: return {0.212, 0.701, 0.087};
+    case ColorSpaceEnum::BT2020: return {0.2627, 0.6780, 0.0593};
+    default: throw std::invalid_argument("Unsupported ColorSpaceEnum");
+  }
+}
+
+enum class ColorRange {
+  UNKNOWN,
+  FULL,
+  LIMITED
+};
+
+// Must match https://developer.android.com/reference/androidx/media3/common/C.ColorRange
+enum ColorRangeMedia3 {
+  COLOR_RANGE_NO_VALUE = -1,
+  COLOR_RANGE_FULL = 1,
+  COLOR_RANGE_LIMITED = 2,
+};
+
+constexpr ColorRange getColorRangeFromMedia3ColorRange(ColorRangeMedia3 color_range) {
+  switch (color_range) {
+    case ColorRangeMedia3::COLOR_RANGE_NO_VALUE:
+    case ColorRangeMedia3::COLOR_RANGE_LIMITED:
+      return ColorRange::LIMITED;
+    case ColorRangeMedia3::COLOR_RANGE_FULL: return ColorRange::FULL;
+    default: return ColorRange::UNKNOWN;
+  }
+}
+
+class ColorConverter {
+ private:
+  ColorSpace color_space;
+  ColorRange color_range;
+
+ public:
+  ColorConverter(ColorSpace color_space, ColorRange color_range)
+      : color_space(color_space), color_range(color_range) {}
+
+  YCbCr rgb_to_ycbcr(double r, double g, double b) const {
+    // y_prime is [0, 1]
+    // pb/pr are [-0.5, 0.5]
+    double y_prime = color_space.kr * r + color_space.kg * g + color_space.kb * b;
+    double pb = 0.5 * (b - y_prime) / (1.0 - color_space.kb);
+    double pr = 0.5 * (r - y_prime) / (1.0 - color_space.kr);
+
+    double y, cb, cr;
+    if (color_range == ColorRange::FULL) {
+      // y is [0, 255]
+      // cb/cr are [0.5, 255.5] (but, anything above 255.5 is clipped to 255)
+      y = y_prime * 255.0;
+      cb = std::min(pb * 255.0 + 128.0, 255.0);
+      cr = std::min(pr * 255.0 + 128.0, 255.0);
+    } else if (color_range == ColorRange::LIMITED) {
+      // y is [16, 235]
+      // cb/cr are [16, 240]
+      y = y_prime * 219.0 + 16.0;
+      cb = pb * 224.0 + 128.0;
+      cr = pr * 224.0 + 128.0;
+    } else {
+      throw std::invalid_argument("Unsupported ColorRange");
+    }
+    return YCbCr{y, cb, cr};
+  }
+
+  RGB ycbcr_to_rgb(double y, double cb, double cr) const {
+    double y_prime, pb, pr;
+    if (color_range == ColorRange::FULL) {
+      // y is [0, 255] -> y_prime is [0, 1]
+      // cb/cr are [0.5, 255] -> pb/pr are [-0.5, 0.5]
+      y_prime = y / 255.0;
+      pb = (cb - 128.0) / 255.0;
+      pr = (cr - 128.0) / 255.0;
+    } else if (color_range == ColorRange::LIMITED) {
+      // y is [16, 235] -> y_prime is [0, 1]
+      // cb/cr are [16, 240] -> pb/pr are [-0.5, 0.5]
+      y_prime = (y - 16.0) / 219.0;
+      pb = (cb - 128.0) / 224.0;
+      pr = (cr - 128.0) / 224.0;
+    } else {
+      throw std::invalid_argument("Unsupported ColorRange");
+    }
+
+    double r = y_prime + pr * (1.0 - color_space.kr) * 2.0;
+    double b = y_prime + pb * (1.0 - color_space.kb) * 2.0;
+    double g = (y_prime - color_space.kr * r - color_space.kb * b) / color_space.kg;
+
+    return RGB(std::clamp(r, 0.0, 1.0), std::clamp(g, 0.0, 1.0), std::clamp(b, 0.0, 1.0));
+  }
+
+  static RGB rgb_to_rgb(
+      const ColorSpace src_color_space,
+      const ColorRange src_color_range,
+      const ColorSpace dst_color_space,
+      const ColorRange dst_color_range,
+      const RGB src_rgb
+  ) {
+    ColorConverter src_converter(src_color_space, src_color_range);
+    ColorConverter dst_converter(dst_color_space, dst_color_range);
+
+    YCbCr ycbcr = src_converter.rgb_to_ycbcr(src_rgb.r_prime, src_rgb.g_prime, src_rgb.b_prime);
+    return dst_converter.ycbcr_to_rgb(ycbcr.y, ycbcr.cb, ycbcr.cr);
+  }
+};
+
+
+
 static void draw_ass_rgba(uint8_t *dst, ptrdiff_t dst_stride,
                           const uint8_t *src, ptrdiff_t src_stride,
-                          int w, int h, uint32_t color) {
-  const uint8_t ass_r = (color >> 24) & 0xff; // Red (bits 24-31)
-  const uint8_t ass_g = (color >> 16) & 0xff; // Green (bits 16-23)
-  const uint8_t ass_b = (color >> 8) & 0xff; // Blue (bits 8-15)
-  const uint8_t ass_a = 0xff - (color & 0xff); // Inverted Alpha (ASS uses 0 = opaque)
+                          int w, int h, RGB color, uint8_t alpha) {
 
   // From libass: https://github.com/libass/libass/blob/1b699559025185e34d21a24cac477ca360cb917d/test/test.c#L149-L165
   const uint16_t ROUNDING_OFFSET = 255 * 255 / 2;
   for (size_t y = 0; y < h; y++) {
     for (size_t x = 0; x < w; x++) {
-      uint16_t k = src[x] * ass_a;
-      dst[x * 4 + 0] = (k * ass_r + (255 * 255 - k) * dst[x * 4 + 0] + ROUNDING_OFFSET) / (255 * 255);
-      dst[x * 4 + 1] = (k * ass_g + (255 * 255 - k) * dst[x * 4 + 1] + ROUNDING_OFFSET) / (255 * 255);
-      dst[x * 4 + 2] = (k * ass_b + (255 * 255 - k) * dst[x * 4 + 2] + ROUNDING_OFFSET) / (255 * 255);
+      uint16_t k = src[x] * alpha;
+      dst[x * 4 + 0] = (k * color.r + (255 * 255 - k) * dst[x * 4 + 0] + ROUNDING_OFFSET) / (255 * 255);
+      dst[x * 4 + 1] = (k * color.g + (255 * 255 - k) * dst[x * 4 + 1] + ROUNDING_OFFSET) / (255 * 255);
+      dst[x * 4 + 2] = (k * color.b + (255 * 255 - k) * dst[x * 4 + 2] + ROUNDING_OFFSET) / (255 * 255);
       dst[x * 4 + 3] = (k * 255   + (255 * 255 - k) * dst[x * 4 + 3] + ROUNDING_OFFSET) / (255 * 255);
     }
     src += src_stride;
@@ -241,7 +414,7 @@ LIBASS_FUNC(void, assProcessCodecPrivate, jlong ass_track_ptr, jbyteArray data) 
  * Renders a frame for a specific track at the given timestamp.
  * This implementation includes diagnostic logging to help debug rendering issues.
  */
-LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr, jint frame_width, jint frame_height, jlong time_ms) {
+LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr, jint frame_width, jint frame_height, jlong time_ms, jint video_color_space, jint video_color_range) {
   jclass resultClass = env->FindClass("androidx/media3/decoder/ass/AssRenderResult");
   jmethodID resultConstructor = env->GetMethodID(resultClass, "<init>", "(Landroid/graphics/Bitmap;Z)V");
 
@@ -260,6 +433,62 @@ LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr
   if (!detect_change || !img) {
     return env->NewObject(resultClass, resultConstructor, (jobject) nullptr, changedSinceLastCall);
   }
+
+  ColorSpaceEnum dst_color_space_enum = getColorSpaceFromMedia3ColorSpace((ColorSpaceMedia3) video_color_space);
+  if (dst_color_space_enum == ColorSpaceEnum::UNKNOWN) {
+    std::string errorMessage = "The color space " + std::to_string(video_color_space) + " is invalid";
+    env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"), errorMessage.c_str());
+    return env->NewObject(resultClass, resultConstructor, (jobject) nullptr, changedSinceLastCall);
+  }
+
+  ColorRange dst_color_range = getColorRangeFromMedia3ColorRange((ColorRangeMedia3) video_color_range);
+  if (dst_color_range == ColorRange::UNKNOWN) {
+    std::string errorMessage = "The color range " + std::to_string(video_color_range) + " is invalid";
+    env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"), errorMessage.c_str());
+    return env->NewObject(resultClass, resultConstructor, (jobject) nullptr, changedSinceLastCall);
+  }
+
+  ColorSpaceEnum src_color_space_enum = ColorSpaceEnum::UNKNOWN;
+  ColorRange src_color_range = ColorRange::UNKNOWN;
+  switch (track->YCbCrMatrix) {
+    case YCBCR_DEFAULT:
+    case YCBCR_UNKNOWN:
+    case YCBCR_BT601_TV:
+      src_color_space_enum = ColorSpaceEnum::BT601;
+      src_color_range = ColorRange::LIMITED;
+      break;
+    case YCBCR_BT601_PC:
+      src_color_space_enum = ColorSpaceEnum::BT601;
+      src_color_range = ColorRange::FULL;
+      break;
+    case YCBCR_BT709_TV:
+      src_color_space_enum = ColorSpaceEnum::BT709;
+      src_color_range = ColorRange::LIMITED;
+      break;
+    case YCBCR_BT709_PC:
+      src_color_space_enum = ColorSpaceEnum::BT709;
+      src_color_range = ColorRange::FULL;
+      break;
+    case YCBCR_SMPTE240M_TV:
+      src_color_space_enum = ColorSpaceEnum::SMPTE_240M;
+      src_color_range = ColorRange::LIMITED;
+      break;
+    case YCBCR_SMPTE240M_PC:
+      src_color_space_enum = ColorSpaceEnum::SMPTE_240M;
+      src_color_range = ColorRange::FULL;
+      break;
+    case YCBCR_FCC_TV:
+      src_color_space_enum = ColorSpaceEnum::FCC;
+      src_color_range = ColorRange::LIMITED;
+      break;
+    case YCBCR_FCC_PC:
+      src_color_space_enum = ColorSpaceEnum::FCC;
+      src_color_range = ColorRange::FULL;
+      break;
+  }
+
+  ColorSpace src_color_space = getColorSpace(src_color_space_enum);
+  ColorSpace dst_color_space = getColorSpace(dst_color_space_enum);
 
   // Create an Android Bitmap
   jclass bitmapClass = env->FindClass("android/graphics/Bitmap");
@@ -295,6 +524,19 @@ LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr
       continue;
     }
 
+    const uint8_t ass_r = (current->color >> 24) & 0xff; // Red (bits 24-31)
+    const uint8_t ass_g = (current->color >> 16) & 0xff; // Green (bits 16-23)
+    const uint8_t ass_b = (current->color >> 8) & 0xff; // Blue (bits 8-15)
+    const uint8_t ass_a = 0xff - (current->color & 0xff); // Inverted Alpha (ASS uses 0 = opaque)
+
+    RGB src_rgb = RGB(ass_r, ass_g, ass_b);
+    std::optional<RGB> dst_rgb;
+    if (src_color_space_enum == ColorSpaceEnum::UNKNOWN || src_color_range == ColorRange::UNKNOWN) {
+      dst_rgb = src_rgb;
+    } else {
+      dst_rgb = ColorConverter::rgb_to_rgb(src_color_space, src_color_range, dst_color_space, dst_color_range, src_rgb);
+    }
+
     uint8_t *dst = reinterpret_cast<uint8_t *>(pixels) +
         current->dst_y * bitmapInfo.stride + // Vertical offset
         current->dst_x * 4;                  // Horizontal offset (4 bytes per pixel)
@@ -306,7 +548,8 @@ LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr
         current->stride,
         current->w,
         current->h,
-        current->color
+        dst_rgb.value(),
+        ass_a
     );
   }
 

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -28,6 +28,8 @@ class RGB {
   double r_prime, g_prime, b_prime;
   uint8_t r, g, b;
 
+  RGB() = default;
+
   explicit RGB(uint8_t r, uint8_t g, uint8_t b) {
     this->r = r;
     this->g = g;
@@ -526,7 +528,7 @@ LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr
     const uint8_t ass_a = 0xff - (current->color & 0xff); // Inverted Alpha (ASS uses 0 = opaque)
 
     RGB src_rgb = RGB(ass_r, ass_g, ass_b);
-    std::optional<RGB> dst_rgb;
+    RGB dst_rgb;
     if (src_color_space_enum == ColorSpaceEnum::UNKNOWN || src_color_range == ColorRange::UNKNOWN) {
       dst_rgb = src_rgb;
     } else {
@@ -544,7 +546,7 @@ LIBASS_FUNC(jobject, assRenderFrame, jlong ass_renderer_ptr, jlong ass_track_ptr
         current->stride,
         current->w,
         current->h,
-        dst_rgb.value(),
+        dst_rgb,
         ass_a
     );
   }

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -76,9 +76,7 @@ enum ColorSpaceMedia3 {
 
 constexpr ColorSpaceEnum getColorSpaceFromMedia3ColorSpace(ColorSpaceMedia3 color_space) {
   switch (color_space) {
-    case ColorSpaceMedia3::COLOR_SPACE_NO_VALUE:
-    case ColorSpaceMedia3::COLOR_SPACE_BT709:
-      return ColorSpaceEnum::BT709;
+    case ColorSpaceMedia3::COLOR_SPACE_NO_VALUE: case ColorSpaceMedia3::COLOR_SPACE_BT709: return ColorSpaceEnum::BT709;
     case ColorSpaceMedia3::COLOR_SPACE_BT601: return ColorSpaceEnum::BT601;
     case ColorSpaceMedia3::COLOR_SPACE_BT2020: return ColorSpaceEnum::BT2020;
     default: return ColorSpaceEnum::UNKNOWN;

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -109,9 +109,7 @@ enum ColorRangeMedia3 {
 
 constexpr ColorRange getColorRangeFromMedia3ColorRange(ColorRangeMedia3 color_range) {
   switch (color_range) {
-    case ColorRangeMedia3::COLOR_RANGE_NO_VALUE:
-    case ColorRangeMedia3::COLOR_RANGE_LIMITED:
-      return ColorRange::LIMITED;
+    case ColorRangeMedia3::COLOR_RANGE_NO_VALUE: case ColorRangeMedia3::COLOR_RANGE_LIMITED: return ColorRange::LIMITED;
     case ColorRangeMedia3::COLOR_RANGE_FULL: return ColorRange::FULL;
     default: return ColorRange::UNKNOWN;
   }

--- a/libraries/decoder_ass/src/main/jni/native-lib.cpp
+++ b/libraries/decoder_ass/src/main/jni/native-lib.cpp
@@ -1,10 +1,8 @@
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
 #include <android/log.h>
-#include <algorithm>
 #include <cmath>
 #include <jni.h>
-#include <optional>
 #include <string>
 #include <android/bitmap.h>
 #include "ass/ass.h"


### PR DESCRIPTION
Permet d'adresser ce issue: https://github.com/moi15moi/libass-prototype/issues/4

Les formules sont basé sur: https://en.wikipedia.org/wiki/YCbCr#R'G'B'_to_Y%E2%80%B2PbPr

Le code me semble complexe. Avez-vous des suggestions pour le rendre plus simple ?

Je n'ai pas encore pu totalement confirmé que la conversion dans ``ColorConverter``.
J'ai testé avec la vidéo dans cet issue: https://github.com/libass/JavascriptSubtitlesOctopus/issues/152
Cela a permit de tester la conversion ``ColorSpace=BT601; ColorRange=LIMITED`` à ``ColorSpace=BT709; ColorRange=LIMITED``
Avant:
![Screenshot_20250403-121815](https://github.com/user-attachments/assets/00e61ac3-36d5-4518-98e9-e36a0f9c0745)

Après (je ne sais pas pourquoi, mais dans mon screenshot, le rectangle à une couleur différente. Pourtant, lorsque je regarde mon téléphone, on ne distingue pas le rectangle. J'imagine que le screenshot brise les couleurs, donc ne vous fiez par à mon screenshot, tester-le vous-même):
![Screenshot_20250403-121558](https://github.com/user-attachments/assets/9bb3b996-9940-4092-bb7e-700af5f4bcae)
